### PR TITLE
Add certificate request ability with CSR

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,11 +1,20 @@
 TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=puppetca
+PLUGIN_NAME=terraform-provider-puppetca
+PLUGIN_VERSION=1.0.0
 
 default: build
 
 build: fmtcheck
 	go install
+
+# Install to the legacy plugin path for local testing/development
+local-install: build
+	@echo "Installing provider to ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)/$(PLUGIN_NAME)"
+	@mkdir -p ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)
+	@cp $(PLUGIN_NAME) ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)/$(PLUGIN_NAME)
+	@echo "Local install complete! Legacy plugin path: ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)/$(PLUGIN_NAME)"
 
 test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4

--- a/README.md
+++ b/README.md
@@ -52,12 +52,39 @@ resource "puppetca_certificate" "ec2instance" {
   name   = "0a7842c26ad1.foo.com"
   usedby = aws_instance.ec2instance.id
 }
+
+# Example: Passing a CSR to the Puppet CA
+resource "tls_private_key" "example" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_cert_request" "example" {
+  private_key_pem = tls_private_key.example.private_key_pem
+
+  subject {
+    common_name  = "foo.example.com"
+    organization = "Example Org"
+  }
+}
+
+resource "puppetca_certificate" "csr_example" {
+  name = "foo.example.com"
+  csr  = tls_cert_request.example.cert_request_pem
+  sign = true
+}
 ```
 
 The first `puppetca_certificate` resource, `test`, will remove the certificate if a destroy plan is run.
 The second `puppetca_certificate` resource, `ec2instance`, will remove the certificate if Terraform destroys the EC2 instance.
 
 The `usedby` parameter can be populated as a resource parameter to drive the removal of the certificate from the Puppet CA at the desired time.  In the example above, if a Terraform plan has to recreate the EC2 instance, the certificate will be removed when the EC2 instance is destroyed since each EC2 instance is assigned a new instance id.
+
+The `csr` parameter allows you to pass a Certificate Signing Request (CSR) to the Puppet CA. In the example above:
+- A private key is generated using the `tls_private_key` resource.
+- A CSR is created using the `tls_cert_request` resource.
+- The CSR is passed to the `puppetca_certificate` resource using the `csr` attribute.
+- The `sign` parameter ensures the certificate is signed automatically after submission.
 
 The provider can also be configured using environment variables:
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -1,0 +1,49 @@
+# Resource: puppetca_certificate
+
+Manages Puppet CA certificates.  
+**New in v1.0.0:** You can now submit a Certificate Signing Request (CSR) directly from Terraform.
+
+## Example Usage
+
+### Submit and Sign a CSR
+
+```hcl
+resource "puppetca_certificate" "mycert" {
+  name = "myhost.example.com"
+  csr  = file("myhost.csr")
+  sign = true
+}
+```
+
+### Retrieve a Signed Certificate
+
+```hcl
+output "cert" {
+  value = puppetca_certificate.mycert.cert
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required): The node name for the certificate.
+- `csr` (String, Optional): The PEM-encoded CSR to submit to the Puppet CA. If omitted, the provider will only attempt to retrieve or sign an existing CSR.
+- `sign` (Bool, Optional): Whether to sign the certificate after CSR submission. Defaults to `false`.
+- `env` (String, Optional): Puppet environment name.
+- `usedby` (String, Optional): An optional string to indicate who or what uses this certificate.
+
+## Attribute Reference
+
+- `cert` (String): The signed certificate in PEM format.
+
+## Import
+
+Import is supported using:
+
+```
+terraform import puppetca_certificate.example "nodename,environment"
+```
+
+## Notes
+
+- The `csr` field must contain a valid PEM-encoded CSR. Use `file("path/to/file.csr")` to load from disk.
+- If `sign` is `true`, the provider will attempt to sign the submitted CSR after submission.


### PR DESCRIPTION
This pull request introduces support for submitting and signing Certificate Signing Requests (CSRs) in the `terraform-provider-puppetca`, along with enhancements to documentation, examples, and local testing workflows. The key changes include updates to the resource schema, new functionality for handling CSRs, and improved documentation to guide users.

### Support for CSR Submission and Signing:
* Added a new `csr` attribute to the `puppetca_certificate` resource schema, allowing users to submit PEM-encoded CSRs to the Puppet server. [[1]](diffhunk://#diff-9907454b5ce0e471810e84b5b946b49fea2cef7ff1068731ce142597762d1c4cR31) [[2]](diffhunk://#diff-9907454b5ce0e471810e84b5b946b49fea2cef7ff1068731ce142597762d1c4cR63-R66)
* Implemented logic to handle CSR submission, validation, and optional signing in the `Create` method of the `puppetca_certificate` resource. This includes preventing the simultaneous use of `sign` and `csr` attributes.
* Introduced a new helper function `submitCSR` to handle the CSR submission process.

### Documentation and Examples:
* Updated `README.md` with examples demonstrating how to submit and sign CSRs, as well as how to configure the provider for local testing. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54-R99) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159-R206)
* Added a new `docs/resources/certificate.md` file to document the `puppetca_certificate` resource, including the new `csr` attribute and its usage.

### Local Development Enhancements:
* Updated `GNUmakefile` with a `local-install` target to simplify local testing by installing the provider to the legacy plugin path.